### PR TITLE
twrp-12.1: Add LineageOS GCC 4.9 Dependency

### DIFF
--- a/twrp-default.xml
+++ b/twrp-default.xml
@@ -90,6 +90,9 @@
     <project name="android_vendor_qcom_opensource_interfaces" path="vendor/qcom/opensource/interfaces" remote="LineageOS" revision="lineage-19.1" />
     <project name="android_vendor_qcom_opensource_vibrator" path="vendor/qcom/opensource/vibrator" remote="LineageOS" revision="lineage-19.1" />
 
+    <!-- GCC 4.9 -->
+    <project name="android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9" path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" remote="LineageOS" revision="lineage-19.1" />
+
     <!-- LAST: Remove unused projects for minimal manifest -->
     <include name="remove-minimal.xml"/>
 </manifest>


### PR DESCRIPTION
Fixes the Error when the kernel is built from the source

Signed-off-by: Sushrut1101 <guptasushrut@gmail.com>