### PR TITLE
Update Branch for QCOM bootctrl

### DIFF
--- a/twrp-default.xml
+++ b/twrp-default.xml
@@ -93,7 +93,7 @@
     <project name="android_device_qcom_common" path="device/qcom/common" remote="TeamWin" revision="android-12.1" />
     <project name="android_device_qcom_twrp-common" path="device/qcom/twrp-common" remote="TeamWin" revision="android-14" />
 
-    <project name="android_hardware_qcom_bootctrl" path="hardware/qcom-caf/bootctrl" remote="LineageOS" revision="lineage-21.0-caf" />
+    <project name="android_hardware_qcom_bootctrl" path="hardware/qcom-caf/bootctrl" remote="LineageOS" revision="lineage-22.0-caf" />
     <project name="android_vendor_qcom_opensource_display-commonsys-intf" path="vendor/qcom/opensource/commonsys-intf/display" remote="LineageOS" revision="lineage-21.0" />
     <project name="android_vendor_qcom_opensource_interfaces" path="vendor/qcom/opensource/interfaces" remote="LineageOS" revision="lineage-21.0" />
     <project name="android_vendor_qcom_opensource_vibrator" path="vendor/qcom/opensource/vibrator" remote="LineageOS" revision="lineage-21.0" />


### PR DESCRIPTION
On some newer QCOM SOCs such as Pineapple and its variants, bootctrl is now an AIDL service. Support is included starting from the LineageOS 22 branch. Update the branch to this so that bootctrl can start up properly on newer hardware.